### PR TITLE
Add note in readme regarding version in Standard dict

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,11 @@ Your playbooks and roles should declare what version of standards you are
 using, otherwise ansible-review assumes you're using the latest. The declaration
 is done by adding standards version as first line in the file. e.g.
 
+The `version` dict key in a standard is optional. However, if it is not specified,
+ansible-review will just print WARN messages and always exit with `0`. In order to
+break builds and for `pre-commit` to work properly you should set the `version` key
+for every standard.
+
 ```
 # Standards: 1.2
 ```


### PR DESCRIPTION
I spent a fair few hours wondering why pre-commit wasn't printing out anything.  It turned out it was because ansible-review was always exiting with exit code 0.

I finally found this https://github.com/willthames/ansible-review/issues/32 which gave me my answer.

As i wasn't the only one affected by this i thought a quick bit of extra doc would be in order.